### PR TITLE
feat(open): Create open command

### DIFF
--- a/.pushuprc SAMPLE.json
+++ b/.pushuprc SAMPLE.json
@@ -1,5 +1,6 @@
 {
   "format": "TICKET-zp-BRANCH",
   "ticketPrefix": "ZACH-",
-  "gitRemote": "origin"
+  "gitRemote": "origin",
+  "ticketUrl": "https://company.atlassian.net/browse/TICKET"
 }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,17 @@ Your configuration file may contain the following keys:
 
 - `gitRemote` _(default: `origin`)_ - The name of the git remote that should be pushed to.
 
+- `ticketUrl` _default: `""`)_ - The URL of a ticket in your ticketing system. You must include `TICKET` somewhere in this URL as a placeholder for the ticket number that is being opened.
+
+If you're using Jira as your ticking system for example, this might look something like:
+
+```json
+"ticketUrl": "https://company.atlassian.net/browse/TICKET"
+```
+
 ## CLI Commands
+
+All CLI options also have an identically named config value. Please see the [config file contents](#config-file-contents) section for more information about each option.
 
 ### `pushup create [ticket]`
 
@@ -94,13 +104,12 @@ Automatically create remote git branches that follow your team's standard.
 
 As stated above, the simplest usage of the CLI is just `pushup 44`, where `44` is your ticket identifier. This wil be combined with either your configuration file or the default options to publish a remote branch.
 
-All configuration options also have an identically named CLI flag. If both are present, the CLI flag will take precedence. Please see the [config file contents](#config-file-contents) section for more information about each option.
+Supports the following options:
 
 - `--format`
 - `--ticketPrefix`, `-p`
 - `--gitRemote`, `-r`
-
-Finally, you prefer passing flags to positional arguments because they're better labeled, there are also the `--ticket` or `-t` flags to pass the ticket identifier.
+- `--ticket`, `-t` (identical to `[ticket]` argument)
 
 Any unknown options will be passed along to `git`.
 
@@ -108,13 +117,35 @@ Any unknown options will be passed along to `git`.
 
 Automatically delete the remote git branch corresponding to a particular ticket number.
 
-Supports exactly the same options as the `create` command.
+Supports the following options:
+
+- `--format`
+- `--ticketPrefix`, `-p`
+- `--gitRemote`, `-r`
+- `--ticket`, `-t` (identical to `[ticket]` argument)
+
+Any unknown options will be passed along to `git`.
 
 ### `pushup init`
 
 Create a pushup config file via interactive prompts.
 
-Supports exactly the same options as the `create` command, with the exception of `--ticket, -t`.
+Supports the following options:
+
+- `--format`
+- `--ticketPrefix`, `-p`
+- `--gitRemote`, `-r`
+
+### `pushup open [ticket]`
+
+Open a ticket in your web browser. Requires a `ticketUrl` either in your config file or supplied as a CLI option.
+
+Supports the following options:
+
+- `--format`
+- `--ticketPrefix`, `-p`
+- `--ticketUrl`, `-u`
+- `--ticket`, `-t` (identical to `[ticket]` argument)
 
 ## Running locally
 

--- a/README.md
+++ b/README.md
@@ -25,25 +25,25 @@ To follow this standard, devs will often create a local branch in that format an
 
 1. Install `pushup` globally with either npm or yarn:
 
-```bash
-# Install with NPM
-npm i -g pushup-cli
+   ```bash
+   # Install with NPM
+   npm i -g pushup-cli
 
-# Or install with yarn
-yarn global add pushup-cli
-```
+   # Or install with yarn
+   yarn global add pushup-cli
+   ```
 
-2. Create a [configuration file](#configuration-file) by running `pushup init`.
+2. Create a [configuration file](#configuration-file) by running `pushup init` and following the prompts.
 
 3. Now, pushing a remote branch is as simple as
 
-```bash
-➜  git checkout -b myBranch
-Switched to a new branch 'myBranch'
+   ```bash
+   ➜  git checkout -b myBranch
+   Switched to a new branch 'myBranch'
 
-➜  pushup 123 # Where 123 is your ticket number
-Branch 'myBranch' set up to track remote branch 'zp-NVM-123-myBranch' from 'origin'.
-```
+   ➜  pushup 123 # Where 123 is your ticket number
+   Branch 'myBranch' set up to track remote branch 'zp-NVM-123-myBranch' from 'origin'.
+   ```
 
 ## Configuration File
 
@@ -55,7 +55,7 @@ pushup uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig#cosmiconf
 
 You can place your config file directly in your project so that your whole team can take advantage of it, or in your home directory for your personal use.
 
-Placing the config directly in the project is nice because that allows customizing the ticket prefix on a per-project basis. You can also customize config options via the [CLI options](#CLI-Commands).
+Placing the config directly in the project is nice because that allows customizing the ticket prefix on a per-project basis. You can also customize config values via the [CLI options](#CLI-Commands) each time you run a command.
 
 ### Config file contents
 
@@ -76,21 +76,23 @@ Your configuration file may contain the following keys:
   zp-TICKET-BRANCH
   ```
 
-- `ticketPrefix` _(default: `""`)_ - The alphabetic prefix that should be appended to ticket IDs. For example, if this is set to `FOO-`, the command `pushup 44` will result in BRANCH (one of the `format` placeholders) being equal to `FOO-44`.
+- `ticketPrefix` _(default: `""`)_ - The prefix that appears at the beginning of all of your ticket numbers. This prefix is typically used to identify which project a particular ticket is associated with.
 
-  If you want the alphabetic portion of the ticket number to be separated from the numeric portion, your `ticketPrefix` must end with that divider, for example a dash `-` as shown in the previous example.
+  For example, if this is set to `FOO-`, the command `pushup 44` will result in BRANCH (one of the `format` placeholders) being equal to `FOO-44`.
 
-  This prefix can also be supplied directly to the `pushup` command: `pushup BAR-123`. Doing so will cause `ticketPrefix` to be ignored.
+  > If your ticket numbers contain a divider (like a dash "-" for example), make sure that divider is included in your `ticketPrefix`.
+
+  This prefix can also be supplied all at once along with your ticket ID, like `pushup BAR-123`. Doing so will cause `ticketPrefix` to be ignored.
 
 - `gitRemote` _(default: `origin`)_ - The name of the git remote that should be pushed to.
 
-- `ticketUrl` _default: `""`)_ - The URL of a ticket in your ticketing system. You must include `TICKET` somewhere in this URL as a placeholder for the ticket number that is being opened.
+- `ticketUrl` (_default: `""`)_ - The URL of a ticket in your ticketing system. You must include `TICKET` somewhere in this URL as a placeholder for the ticket number that is being opened.
 
-If you're using Jira as your ticking system for example, this might look something like:
+  If you're using Jira as your ticking system for example, this might look something like:
 
-```json
-"ticketUrl": "https://company.atlassian.net/browse/TICKET"
-```
+  ```json
+  "ticketUrl": "https://company.atlassian.net/browse/TICKET"
+  ```
 
 ## CLI Commands
 
@@ -115,7 +117,7 @@ Any unknown options will be passed along to `git`.
 
 ### `pushup delete [ticket]`
 
-Automatically delete the remote git branch corresponding to a particular ticket number.
+Automatically delete the remote git branch corresponding to a particular ticket number. If a ticket number is not supplied, a best guess is made and suggested to you when possible.
 
 Supports the following options:
 
@@ -150,7 +152,7 @@ Supports the following options:
 ## Running locally
 
 1. Clone the repo
-1. Create a [configuration file](#configuration-file) by running `pushup init`
+1. Create a [configuration file](#configuration-file) by running `pushup init` and following the prompts
 1. Install dependencies with: `yarn install`
 1. Allow running `pushup` in the terminal to run invoke project: `npm link`
    - _Yarn's link command does not respect the `bin` field in the package.json currently_

--- a/package.json
+++ b/package.json
@@ -28,5 +28,20 @@
   },
   "devDependencies": {
     "jest": "^27.0.6"
-  }
+  },
+  "keywords": [
+    "git",
+    "branch",
+    "management",
+    "remote",
+    "push",
+    "team",
+    "standard",
+    "standards",
+    "format",
+    "jira",
+    "ticket",
+    "number",
+    "automatic"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "cosmiconfig": "^7.0.0",
     "execa": "^5.1.1",
     "inquirer": "^8.1.2",
-    "node-emoji": "^1.11.0"
+    "node-emoji": "^1.11.0",
+    "open": "^8.2.1"
   },
   "devDependencies": {
     "jest": "^27.0.6"

--- a/src/cli.js
+++ b/src/cli.js
@@ -64,4 +64,23 @@ cli
     'The git remote that a branch should be deleted from',
   )
 
+cli
+  .command('open')
+  .description('Open a ticket in your web browser')
+  .action(require('./commands/open'))
+  .argument('[ticket]', 'A ticket identifier')
+  .option('-t, --ticket <ticket>', 'A ticket identifier')
+  .option(
+    '--format <format>',
+    'The format of the name of the remote branch name to be deleted',
+  )
+  .option(
+    '-p, --ticketPrefix <ticketPrefix>',
+    'The alphabetic prefix that should be appended to ticket IDs',
+  )
+  .option(
+    '-u, --ticketUrl <ticketUrl>',
+    'The format of the URLs for your ticketing system',
+  )
+
 cli.version(package.version).parse(process.argv)

--- a/src/commands/create/create-branch-name.js
+++ b/src/commands/create/create-branch-name.js
@@ -1,7 +1,7 @@
-const {getCurrentBranchName, determineTicketNumber} = require('../../util')
+const {getCurrentBranchName, ticketIdPrefixToNumber} = require('../../util')
 
 async function createBranchName({ticketId, format, ticketPrefix}) {
-  const ticketNumber = determineTicketNumber({ticketId, ticketPrefix})
+  const ticketNumber = ticketIdPrefixToNumber({ticketId, ticketPrefix})
   const localBranchName = await getCurrentBranchName()
 
   let remoteBranchName = format

--- a/src/commands/delete/find-branch-name.js
+++ b/src/commands/delete/find-branch-name.js
@@ -2,11 +2,11 @@ const execa = require('execa')
 const inquirer = require('inquirer')
 const chalk = require('chalk')
 
-const {determineTicketNumber, error} = require('../../util')
+const {ticketIdPrefixToNumber, error} = require('../../util')
 const createBranchName = require('../create/create-branch-name')
 
 async function findBranchName({ticketId, format, ticketPrefix}) {
-  const ticketNumber = determineTicketNumber({ticketId, ticketPrefix})
+  const ticketNumber = ticketIdPrefixToNumber({ticketId, ticketPrefix})
   const {stdout: rawRemoteBranches} = await execa('git', ['branch', '-r'])
 
   // Git prints remote branch prefixed with the remote

--- a/src/commands/init/init.js
+++ b/src/commands/init/init.js
@@ -6,8 +6,9 @@ const inquirer = require('inquirer')
 const chalk = require('chalk')
 const execa = require('execa')
 const emoji = require('node-emoji')
+const {error} = require('../../util')
 
-const textEntryPoint = chalk.red('>> ')
+const textEntryPoint = chalk.blue('--> ')
 
 async function init(options) {
   await checkForExistingConfig()
@@ -16,22 +17,29 @@ async function init(options) {
   const gitRemotes = gitRemotesRaw.split('\n')
   const {stdout: cwd} = await execa('pwd')
 
-  const {fileLocation, format, ticketPrefix, gitRemote} = await promptUser({
-    gitRemotes,
-    cwd,
-    options,
-  })
+  const {fileLocation, format, ticketPrefix, gitRemote, ticketUrl} =
+    await promptUser({
+      gitRemotes,
+      cwd,
+      options,
+    })
 
   const finalConfigValues = {
     format: options.format || format,
     ticketPrefix: options.ticketPrefix || ticketPrefix,
     gitRemote: options.gitRemote || gitRemote,
+    ticketUrl: options.ticketUrl || ticketUrl,
   }
 
   // Remove any undefined values from config
   Object.entries(finalConfigValues).forEach(([key, value]) => {
-    if (value == undefined) delete finalConfigValues[key]
+    if (!value) delete finalConfigValues[key]
   })
+
+  if (!Object.keys(finalConfigValues).length) {
+    error('No valid config values were supplied, not creating a config')
+    process.exit(0)
+  }
 
   const configFilePath = path.resolve(fileLocation, '.pushuprc.json')
   fs.writeFileSync(configFilePath, JSON.stringify(finalConfigValues, null, 2))
@@ -109,6 +117,26 @@ async function promptUser({gitRemotes, cwd, options}) {
       message: 'Which git remote should branches be pushed to by default?',
       choices: gitRemotes,
       when: gitRemotes.length > 1 && !options.gitRemote,
+    },
+    {
+      name: 'ticketUrl',
+      type: 'input',
+      message: [
+        `What is the URL of a ticket in your ticketing system?`,
+        chalk.gray('  Use TICKET as a placeholder for the ticket number'),
+        textEntryPoint,
+      ].join('\n'),
+      when: !options.ticketUrl,
+      validate(enteredTicketUrl) {
+        if (enteredTicketUrl && !enteredTicketUrl.includes('TICKET')) {
+          return 'Your ticket URL must include "TICKET" as a placeholder for the ticket number'
+        }
+        if (enteredTicketUrl && !enteredTicketUrl.startsWith('http://')) {
+          return 'Your ticket URL must start with "http://"'
+        }
+
+        return true
+      }
     },
   ])
 }

--- a/src/commands/open/find-ticket-numbers.js
+++ b/src/commands/open/find-ticket-numbers.js
@@ -1,0 +1,42 @@
+const {
+  getCurrentRemoteTrackingBranch,
+  ticketIdPrefixToNumber,
+} = require('../../util')
+const parseTicketsFromBranch = require('./parse-tickets-from-branch')
+
+/**
+ * Search through the CLI options and the name of the remote tracking
+ * branch of the currently checked out git branch to try and find a
+ * ticket number with the given prefix.
+ * @returns {string[]} Any ticket numbers that could be located
+ * from a given source.  Only ticket numbers from a single source
+ * (the CLI inputs or the branch name) will be returned, and
+ * preference is given to ticket numbers from any source that
+ * include the passed ticket prefix.
+ */
+async function findTicketNumbers({ticketId, ticketPrefix}) {
+  const ticketNumberFromInputs = ticketIdPrefixToNumber({
+    ticketId,
+    ticketPrefix,
+  })
+  const ticketNumbersFromBranch = parseTicketsFromBranch({
+    ticketPrefix,
+    branch: await getCurrentRemoteTrackingBranch(),
+  })
+
+  if (ticketPrefix) {
+    // The presence of a ticket prefix option indicates that the
+    // URL must have a ticket prefix
+    return ticketNumberFromInputs.includes(ticketPrefix)
+      ? [ticketNumberFromInputs]
+      : ticketNumbersFromBranch.some(ticket => ticket.includes(ticketPrefix))
+      ? ticketNumbersFromBranch
+      : null
+  }
+
+  return ticketNumberFromInputs
+    ? [ticketNumberFromInputs]
+    : ticketNumbersFromBranch
+}
+
+module.exports = findTicketNumbers

--- a/src/commands/open/find-ticket-numbers.js
+++ b/src/commands/open/find-ticket-numbers.js
@@ -31,12 +31,10 @@ async function findTicketNumbers({ticketId, ticketPrefix}) {
       ? [ticketNumberFromInputs]
       : ticketNumbersFromBranch.some(ticket => ticket.includes(ticketPrefix))
       ? ticketNumbersFromBranch
-      : null
+      : []
   }
 
-  return ticketNumberFromInputs
-    ? [ticketNumberFromInputs]
-    : ticketNumbersFromBranch
+  return ticketNumbersFromBranch
 }
 
 module.exports = findTicketNumbers

--- a/src/commands/open/find-ticket-numbers.js
+++ b/src/commands/open/find-ticket-numbers.js
@@ -34,7 +34,9 @@ async function findTicketNumbers({ticketId, ticketPrefix}) {
       : []
   }
 
-  return ticketNumbersFromBranch
+  return ticketNumberFromInputs
+    ? [ticketNumberFromInputs]
+    : ticketNumbersFromBranch
 }
 
 module.exports = findTicketNumbers

--- a/src/commands/open/find-ticket-numbers.test.js
+++ b/src/commands/open/find-ticket-numbers.test.js
@@ -1,0 +1,110 @@
+const findTicketNumbers = require('./find-ticket-numbers')
+const {getCurrentRemoteTrackingBranch} = require('../../util')
+
+jest.mock('../../util', () => {
+  const actualUtil = jest.requireActual('../../util')
+
+  return {
+    ...actualUtil,
+    getCurrentRemoteTrackingBranch: jest.fn(),
+  }
+})
+
+beforeEach(() => {
+  // This is the default branch name if mockResolvedValueOnce()
+  // is not called in a particular test
+  getCurrentRemoteTrackingBranch.mockResolvedValue('myBranch')
+})
+
+it('finds prefixed ticket number in remote branch name', async () => {
+  getCurrentRemoteTrackingBranch.mockResolvedValueOnce('zp-ZACH-123__foo')
+
+  const result = await findTicketNumbers({ticketPrefix: 'ZACH-'})
+  expect(result).toHaveLength(1)
+  expect(result).toContain('ZACH-123')
+})
+
+it('finds multiple prefixed ticket numbers in remote branch name', async () => {
+  getCurrentRemoteTrackingBranch.mockResolvedValueOnce(
+    'zp-ZACH-123__fooZACH-999',
+  )
+
+  const result = await findTicketNumbers({ticketPrefix: 'ZACH-'})
+  expect(result).toHaveLength(2)
+  expect(result).toContain('ZACH-123')
+  expect(result).toContain('ZACH-999')
+})
+
+it('finds prefixed ticket number for numeric input', async () => {
+  const result = await findTicketNumbers({
+    ticketPrefix: 'ZACH-',
+    ticketId: '444',
+  })
+
+  expect(result).toHaveLength(1)
+  expect(result).toContain('ZACH-444')
+})
+
+it('finds prefixed ticket number for prefixed input', async () => {
+  const result = await findTicketNumbers({
+    ticketPrefix: 'ZACH-',
+    ticketId: 'ZACH-666',
+  })
+
+  expect(result).toHaveLength(1)
+  expect(result).toContain('ZACH-666')
+})
+
+it('ignores remote branch when prefix is found in numeric input', async () => {
+  getCurrentRemoteTrackingBranch.mockResolvedValueOnce('ZACH-123')
+
+  const result = await findTicketNumbers({
+    ticketPrefix: 'ZACH-',
+    ticketId: '444',
+  })
+
+  expect(result).toHaveLength(1)
+  expect(result).toContain('ZACH-444')
+})
+
+it('ignores remote branch when prefix is found in prefixed input', async () => {
+  getCurrentRemoteTrackingBranch.mockResolvedValueOnce('ZACH-123')
+
+  const result = await findTicketNumbers({
+    ticketPrefix: 'ZACH-',
+    ticketId: 'ZACH-999',
+  })
+
+  expect(result).toHaveLength(1)
+  expect(result).toContain('ZACH-999')
+})
+
+it('returns an array when no prefixed ticket is found in inputs or branch', async () => {
+  const result = await findTicketNumbers({
+    ticketPrefix: 'ZACH-',
+  })
+
+  expect(Array.isArray(result)).toBe(true)
+  expect(result).toHaveLength(0)
+})
+
+it('ignores lone numbers in the branch name when a prefix is present', async () => {
+  getCurrentRemoteTrackingBranch.mockResolvedValueOnce('zp-123__456')
+
+  const result = await findTicketNumbers({
+    ticketPrefix: 'ZACH-',
+  })
+
+  expect(Array.isArray(result)).toBe(true)
+  expect(result).toHaveLength(0)
+})
+
+it('finds lone numbers in the branch name when no prefix is present', async () => {
+  getCurrentRemoteTrackingBranch.mockResolvedValueOnce('zp-123__456')
+
+  const result = await findTicketNumbers({})
+
+  expect(result).toHaveLength(2)
+  expect(result).toContain('123')
+  expect(result).toContain('456')
+})

--- a/src/commands/open/find-ticket-numbers.test.js
+++ b/src/commands/open/find-ticket-numbers.test.js
@@ -108,3 +108,9 @@ it('finds lone numbers in the branch name when no prefix is present', async () =
   expect(result).toContain('123')
   expect(result).toContain('456')
 })
+
+it('finds lone numbers in the input name when no prefix is present', async () => {
+  const result = await findTicketNumbers({ticketId: '123'})
+  expect(result).toHaveLength(1)
+  expect(result).toContain('123')
+})

--- a/src/commands/open/index.js
+++ b/src/commands/open/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./open')

--- a/src/commands/open/open.js
+++ b/src/commands/open/open.js
@@ -1,0 +1,57 @@
+const openUrl = require('open')
+const inquirer = require('inquirer')
+const chalk = require('chalk')
+const {getConfig} = require('../../config')
+const {error} = require('../../util')
+const findTicketNumbers = require('./find-ticket-numbers')
+
+async function open(ticketIdArg, options, commander) {
+  const {
+    ticketId: ticketIdOption,
+    ticketPrefix,
+    ticketUrl,
+  } = getConfig(options, commander)
+
+  if (!ticketUrl) {
+    error(
+      'No ticketUrl could be found.  Please supply it either in your config file or as a CLI option.',
+    )
+  }
+
+  const ticketId = ticketIdOption ?? ticketIdArg
+  const ticketNumbers = await findTicketNumbers({
+    ticketId,
+    ticketPrefix,
+  })
+
+  if (!ticketNumbers) {
+    error('Could not determine ticket number')
+    process.exit(0)
+  }
+
+  let ticketsToOpen = ticketNumbers
+
+  if (ticketNumbers.length > 1) {
+    const {choseTicketNumber} = await inquirer.prompt([
+      {
+        name: 'choseTicketNumber',
+        type: 'list',
+        message:
+          'Multiple possible ticket numbers were found, which would you like to open?',
+        choices: [...ticketNumbers, 'all'],
+      },
+    ])
+
+    if (choseTicketNumber !== 'all') {
+      ticketsToOpen = [choseTicketNumber]
+    }
+  }
+
+  for (let ticketToOpen of ticketsToOpen) {
+    console.log(chalk.gray(`Opening ticket ${ticketToOpen}`))
+    const url = ticketUrl.replace('TICKET', ticketToOpen)
+    openUrl(url)
+  }
+}
+
+module.exports = open

--- a/src/commands/open/open.js
+++ b/src/commands/open/open.js
@@ -31,7 +31,7 @@ async function open(ticketIdArg, options, commander) {
     ticketPrefix,
   })
 
-  if (!ticketNumbers) {
+  if (!ticketNumbers || !ticketNumbers.length) {
     error('Could not determine ticket number')
     process.exit(0)
   }

--- a/src/commands/open/open.js
+++ b/src/commands/open/open.js
@@ -16,6 +16,13 @@ async function open(ticketIdArg, options, commander) {
     error(
       'No ticketUrl could be found.  Please supply it either in your config file or as a CLI option.',
     )
+    process.exit(0)
+  }
+  if (!ticketUrl.includes('TICKET')) {
+    error(
+      'Your ticketUrl must include TICKET as a placeholder to insert the ticket number',
+    )
+    process.exit(0)
   }
 
   const ticketId = ticketIdOption ?? ticketIdArg

--- a/src/commands/open/parse-tickets-from-branch.js
+++ b/src/commands/open/parse-tickets-from-branch.js
@@ -13,7 +13,10 @@ function parseTicketsFromBranch({ticketPrefix, branch}) {
     new RegExp(`(${ticketPrefix}\\d+)`, 'g'),
   )
 
-  return ticketsWithPrefixes ? ticketsWithPrefixes : branch.match(/\d+/g)
+  if (ticketsWithPrefixes) return ticketsWithPrefixes
+
+  const ticketsWithLoneNumbers = branch.match(/\d+/g)
+  return ticketsWithLoneNumbers ? ticketsWithLoneNumbers : []
 }
 
 module.exports = parseTicketsFromBranch

--- a/src/commands/open/parse-tickets-from-branch.js
+++ b/src/commands/open/parse-tickets-from-branch.js
@@ -1,0 +1,19 @@
+/**
+ * Search through a branch name for possible ticket numbers.
+ * If the passed prefix can be found, only ticket numbers including
+ * that prefix will be returned.  If no instance of the prefix was found,
+ * any number will be considered a possible ticket number and returned.
+ * @returns {string[]} An array of strings of the possible ticket
+ * matches or null if no possible matches were found
+ */
+function parseTicketsFromBranch({ticketPrefix, branch}) {
+  if (!branch) return []
+
+  const ticketsWithPrefixes = branch.match(
+    new RegExp(`(${ticketPrefix}\\d+)`, 'g'),
+  )
+
+  return ticketsWithPrefixes ? ticketsWithPrefixes : branch.match(/\d+/g)
+}
+
+module.exports = parseTicketsFromBranch

--- a/src/commands/open/parse-tickets-from-branch.test.js
+++ b/src/commands/open/parse-tickets-from-branch.test.js
@@ -1,0 +1,108 @@
+const parseTicketsFromBranch = require('./parse-tickets-from-branch')
+
+it('finds a ticket prefix', () => {
+  const result = parseTicketsFromBranch({
+    ticketPrefix: 'ZACH-',
+    branch: 'zp-ZACH-123',
+  })
+
+  expect(result).toHaveLength(1)
+  expect(result).toContain('ZACH-123')
+})
+
+it('finds multiple ticket prefixes', () => {
+  const result = parseTicketsFromBranch({
+    ticketPrefix: 'ZACH-',
+    branch: 'zp-ZACH-123__asdf$$ZACH-987',
+  })
+
+  expect(result).toHaveLength(2)
+  expect(result).toContain('ZACH-123')
+  expect(result).toContain('ZACH-987')
+})
+
+it('finds a lone number when no prefix is present', () => {
+  const result = parseTicketsFromBranch({
+    ticketPrefix: 'ZACH-',
+    branch: 'zp-444!!foo',
+  })
+
+  expect(result).toHaveLength(1)
+  expect(result).toContain('444')
+})
+
+it('finds multiple lone numbers when no prefix is present', () => {
+  const result = parseTicketsFromBranch({
+    ticketPrefix: 'ZACH-',
+    branch: 'zp--123987987__asdf$$ZACH-ss7778987fd',
+  })
+
+  expect(result).toHaveLength(2)
+  expect(result).toContain('123987987')
+  expect(result).toContain('7778987')
+})
+
+it('ignores lone numbers when a prefix is present', () => {
+  const result = parseTicketsFromBranch({
+    ticketPrefix: 'ZACH-',
+    branch: 'zp--123987987__asdf$$ZACH-444ZACH-ss7778987fd',
+  })
+
+  expect(result).toHaveLength(1)
+  expect(result).toContain('ZACH-444')
+})
+
+it('returns an array when no branch was passed', () => {
+  let result = parseTicketsFromBranch({
+    ticketPrefix: 'ZACH-',
+    branch: '',
+  })
+  expect(Array.isArray(result)).toBe(true)
+
+  result = parseTicketsFromBranch({
+    ticketPrefix: 'ZACH-',
+    branch: null,
+  })
+  expect(Array.isArray(result)).toBe(true)
+
+  result = parseTicketsFromBranch({
+    ticketPrefix: 'ZACH-',
+  })
+  expect(Array.isArray(result)).toBe(true)
+})
+
+it('returns an array when no ticket prefix was passed', () => {
+  let result = parseTicketsFromBranch({
+    ticketPrefix: '',
+    branch: 'asdf',
+  })
+  expect(Array.isArray(result)).toBe(true)
+
+  result = parseTicketsFromBranch({
+    ticketPrefix: null,
+    branch: 'asdf',
+  })
+  expect(Array.isArray(result)).toBe(true)
+
+  result = parseTicketsFromBranch({
+    branch: 'asdf',
+  })
+  expect(Array.isArray(result)).toBe(true)
+})
+
+it('returns an array when no ticket prefix or branch was passed', () => {
+  let result = parseTicketsFromBranch({
+    ticketPrefix: '',
+    branch: '',
+  })
+  expect(Array.isArray(result)).toBe(true)
+
+  result = parseTicketsFromBranch({
+    ticketPrefix: null,
+    branch: null,
+  })
+  expect(Array.isArray(result)).toBe(true)
+
+  result = parseTicketsFromBranch({})
+  expect(Array.isArray(result)).toBe(true)
+})

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ const defaultConfig = {
   ticketPrefix: '',
   gitRemote: 'origin',
   format: 'TICKET-BRANCH',
+  ticketUrl: '',
 }
 
 /**
@@ -29,12 +30,14 @@ function getConfig(options, commander) {
   const format = options.format ?? config.format
   const ticketPrefix = options.ticketPrefix ?? config.ticketPrefix
   const gitRemote = options.gitRemote ?? config.gitRemote
+  const ticketUrl = options.ticketUrl ?? config.ticketUrl
 
   return {
     ticketId,
     format,
     ticketPrefix,
     gitRemote,
+    ticketUrl,
     unknownOptions,
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -46,10 +46,6 @@ async function getCurrentRemoteTrackingBranch() {
 function ticketIdPrefixToNumber({ticketId, ticketPrefix}) {
   const ticketIdContainsPrefix = ticketId && ticketId.match(/^[a-zA-Z]/)
 
-  if (ticketId && !ticketIdContainsPrefix && !ticketPrefix) {
-    warn('No ticket prefix was found, only the ticket ID will be used')
-  }
-
   return ticketIdContainsPrefix
     ? ticketId
     : ticketPrefix && ticketId

--- a/src/util.js
+++ b/src/util.js
@@ -29,7 +29,21 @@ async function getCurrentBranchName() {
   return localBranchName
 }
 
-function determineTicketNumber({ticketId, ticketPrefix}) {
+async function getCurrentRemoteTrackingBranch() {
+  try {
+    const {stdout: remoteTrackingBranch} = await execa('git', [
+      'rev-parse',
+      '--abbrev-ref',
+      '--symbolic-full-name',
+      '@{u}',
+    ])
+    return remoteTrackingBranch
+  } catch (e) {
+    return null
+  }
+}
+
+function ticketIdPrefixToNumber({ticketId, ticketPrefix}) {
   const ticketIdContainsPrefix = ticketId && ticketId.match(/^[a-zA-Z]/)
 
   if (ticketId && !ticketIdContainsPrefix && !ticketPrefix) {
@@ -50,5 +64,6 @@ module.exports = {
   warn,
   executeGitCommand,
   getCurrentBranchName,
-  determineTicketNumber,
+  getCurrentRemoteTrackingBranch,
+  ticketIdPrefixToNumber,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,6 +1045,11 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -1413,6 +1418,11 @@ is-core-module@^2.2.0:
   dependencies:
     has "^1.0.3"
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
@@ -1452,6 +1462,13 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2144,6 +2161,15 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.2.1.tgz#82de42da0ccbf429bc12d099dad2e0975e14e8af"
+  integrity sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 optionator@^0.8.1:
   version "0.8.3"


### PR DESCRIPTION
The open command allows users to open a ticket number in their browser.  When the currently checked out local branch is tracking a remote branch that contains a ticket number, that number is used automatically without the user having to input any information whatsoever.

Fixes #2 